### PR TITLE
Account for last box in file being a child box

### DIFF
--- a/src/iso_box.js
+++ b/src/iso_box.js
@@ -273,7 +273,8 @@ ISOBox.prototype._parseBox = function() {
 
   switch(this.size) {
   case 0:
-    this._raw = new DataView(this._raw.buffer, this._offset, (this._raw.byteLength - this._cursor.offset + 8));
+    // Size zero indicates last box in the file. Consume remaining buffer.
+    this._raw = new DataView(this._raw.buffer, this._offset);
     break;
   case 1:
     if (this._offset + this.size > this._raw.buffer.byteLength) {


### PR DESCRIPTION
The current calculations seems to assume that the last box is a top level box. Believe we don't need the calculation at all. If this is the last box, consume the remaining buffer. 

From ISO/IEC 14496-12

> size is an integer that specifies the number of bytes in this box, including all its fields and contained
boxes; if size is 1 then the actual size is in the field largesize; if size is 0, then this box is the last
one in the file, and its contents extend to the end of the file 

